### PR TITLE
feat: implement Claude Adapter SDK integration (PR-06)

### DIFF
--- a/packages/runtime-adapters/claude/package.json
+++ b/packages/runtime-adapters/claude/package.json
@@ -15,12 +15,15 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "node ../../scripts/clean.mjs dist"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0"
   },
   "devDependencies": {
-    "typescript": "~5.7.3"
+    "typescript": "~5.7.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/runtime-adapters/claude/src/__tests__/adapter.test.ts
+++ b/packages/runtime-adapters/claude/src/__tests__/adapter.test.ts
@@ -123,6 +123,118 @@ describe('ClaudeAdapter', () => {
       expect(session).toBeDefined();
     });
 
+    it('should throw error when workspaceRoot is missing', async () => {
+      const config = {} as SessionConfig;
+
+      await expect(adapter.createSession(config)).rejects.toThrow('workspaceRoot is required');
+    });
+
+    it('should throw error when workspaceRoot is empty string', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '   ',
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('workspaceRoot cannot be empty');
+    });
+
+    it('should throw error when workspaceRoot is not a string', async () => {
+      const config = {
+        workspaceRoot: 123,
+      } as unknown as SessionConfig;
+
+      await expect(adapter.createSession(config)).rejects.toThrow('workspaceRoot must be a string');
+    });
+
+    it('should throw error when model is empty string', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        model: '',
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('model cannot be empty');
+    });
+
+    it('should throw error when maxTokens is not a positive integer', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        maxTokens: 0,
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('maxTokens must be a positive integer');
+    });
+
+    it('should throw error when maxTokens is negative', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        maxTokens: -100,
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('maxTokens must be a positive integer');
+    });
+
+    it('should throw error when temperature is out of range', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        temperature: 1.5,
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('temperature must be between 0 and 1');
+    });
+
+    it('should throw error when temperature is negative', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        temperature: -0.1,
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('temperature must be between 0 and 1');
+    });
+
+    it('should throw error when maxHistoryMessages is less than 1', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        maxHistoryMessages: 0,
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('maxHistoryMessages must be a positive integer');
+    });
+
+    it('should throw error when tools is not an array', async () => {
+      const config = {
+        workspaceRoot: '/test',
+        tools: 'not an array',
+      } as unknown as SessionConfig;
+
+      await expect(adapter.createSession(config)).rejects.toThrow('tools must be an array');
+    });
+
+    it('should throw error when tool is missing name', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        tools: [{ description: 'A tool', inputSchema: { type: 'object' } } as ToolDefinition],
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('Tool name is required');
+    });
+
+    it('should throw error when tool is missing description', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        tools: [{ name: 'test_tool', inputSchema: { type: 'object' } } as ToolDefinition],
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('Tool "test_tool" description is required');
+    });
+
+    it('should throw error when tool has invalid inputSchema', async () => {
+      const config: SessionConfig = {
+        workspaceRoot: '/test',
+        tools: [{ name: 'test_tool', description: 'A tool', inputSchema: { type: 'string' } } as unknown as ToolDefinition],
+      };
+
+      await expect(adapter.createSession(config)).rejects.toThrow('Tool "test_tool" inputSchema must be an object type');
+    });
+
     it('should create session with tools', async () => {
       const tools: ToolDefinition[] = [
         {

--- a/packages/runtime-adapters/claude/src/index.ts
+++ b/packages/runtime-adapters/claude/src/index.ts
@@ -255,9 +255,14 @@ class ClaudeSession implements AgentSession {
                 name: currentToolUseBlock.name,
                 input,
               };
-            } catch {
-              // If JSON parsing fails, log warning and yield with empty input
-              console.warn(`[ClaudeSession] Failed to parse tool input JSON: ${accumulatedJson}`);
+            } catch (error) {
+              // If JSON parsing fails, log warning with details and yield with empty input
+              // This can happen if the model produces invalid JSON or the stream is interrupted
+              const errorMessage = error instanceof Error ? error.message : 'Unknown parse error';
+              console.warn(
+                `[ClaudeSession] Failed to parse tool input JSON for tool "${currentToolUseBlock.name}" (ID: ${currentToolUseBlock.id}): ${errorMessage}. ` +
+                `Raw JSON: "${accumulatedJson}". Falling back to empty input.`
+              );
               currentToolUseBlock.input = {};
               assistantContent.push(currentToolUseBlock);
               yield {

--- a/packages/runtime-adapters/claude/src/index.ts
+++ b/packages/runtime-adapters/claude/src/index.ts
@@ -1,5 +1,5 @@
-// Claude Runtime Adapter - PR-06 will implement full SDK integration
-// Wraps Claude SDK to provide AgentRuntime interface
+// Claude Runtime Adapter - Wraps Claude SDK to provide AgentRuntime interface
+import Anthropic from '@anthropic-ai/sdk';
 
 export interface AgentRuntime {
   createSession(config: SessionConfig): Promise<AgentSession>;
@@ -16,6 +16,19 @@ export interface SessionConfig {
   model?: string;
   systemPrompt?: string;
   workspaceRoot: string;
+  tools?: ToolDefinition[];
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: 'object';
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
 }
 
 export type RuntimeEvent =
@@ -32,38 +45,264 @@ export interface RuntimeCapabilities {
   maxContextTokens: number;
 }
 
+interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string | Array<Anthropic.Messages.ContentBlockParam>;
+}
+
+class ClaudeSession implements AgentSession {
+  id: string;
+  private client: Anthropic;
+  private config: SessionConfig;
+  private conversationHistory: ConversationMessage[] = [];
+  private abortController: AbortController | null = null;
+
+  constructor(
+    id: string,
+    client: Anthropic,
+    config: SessionConfig
+  ) {
+    this.id = id;
+    this.client = client;
+    this.config = config;
+  }
+
+  async *sendMessage(message: string): AsyncGenerator<RuntimeEvent> {
+    // Create a new abort controller for this request
+    this.abortController = new AbortController();
+
+    try {
+      // Add user message to history
+      this.conversationHistory.push({
+        role: 'user',
+        content: message,
+      });
+
+      // Prepare tool definitions for the API
+      const tools: Anthropic.Messages.ToolUnion[] | undefined = this.config.tools?.map(
+        (tool): Anthropic.Messages.Tool => ({
+          name: tool.name,
+          description: tool.description,
+          input_schema: tool.inputSchema as Anthropic.Messages.Tool.InputSchema,
+        })
+      );
+
+      // Start streaming
+      const stream = this.client.messages.stream(
+        {
+          model: this.config.model ?? 'claude-3-5-sonnet-latest',
+          max_tokens: this.config.maxTokens ?? 8192,
+          temperature: this.config.temperature ?? 0.7,
+          system: this.config.systemPrompt,
+          messages: this.conversationHistory as Anthropic.Messages.MessageParam[],
+          tools,
+        },
+        {
+          signal: this.abortController.signal,
+        }
+      );
+
+      // Track accumulated content for assistant message
+      const assistantContent: Anthropic.Messages.ContentBlock[] = [];
+      let currentTextBlock: { type: 'text'; text: string } | null = null;
+      let currentToolUseBlock: Anthropic.Messages.ToolUseBlock | null = null;
+      let accumulatedJson = '';
+
+      // The stream is an async iterable - iterate over it directly
+      for await (const event of stream) {
+        // Check if cancelled
+        if (this.abortController.signal.aborted) {
+          throw new Error('Request cancelled');
+        }
+
+        // Handle the event based on type
+        const eventType = event.type as string;
+
+        if (eventType === 'content_block_start') {
+          const startEvent = event as Anthropic.Messages.RawContentBlockStartEvent;
+          const block = startEvent.content_block;
+          if (block.type === 'text') {
+            currentTextBlock = { type: 'text', text: '' };
+            assistantContent.push(block);
+          } else if (block.type === 'tool_use') {
+            currentToolUseBlock = {
+              id: block.id,
+              name: block.name,
+              input: block.input,
+              type: 'tool_use',
+            };
+            accumulatedJson = '';
+          }
+        } else if (eventType === 'content_block_delta') {
+          const deltaEvent = event as Anthropic.Messages.RawContentBlockDeltaEvent;
+          const delta = deltaEvent.delta;
+          if (delta.type === 'text_delta' && currentTextBlock) {
+            currentTextBlock.text += delta.text;
+            yield { type: 'text', content: delta.text };
+          } else if (delta.type === 'input_json_delta' && currentToolUseBlock) {
+            accumulatedJson += delta.partial_json;
+          }
+        } else if (eventType === 'content_block_stop') {
+          if (currentToolUseBlock) {
+            // Parse the accumulated JSON for tool input
+            try {
+              const input = accumulatedJson ? JSON.parse(accumulatedJson) : {};
+              currentToolUseBlock.input = input;
+              assistantContent.push(currentToolUseBlock);
+              yield {
+                type: 'tool_use',
+                id: currentToolUseBlock.id,
+                name: currentToolUseBlock.name,
+                input,
+              };
+            } catch {
+              // If JSON parsing fails, yield with empty input
+              currentToolUseBlock.input = {};
+              assistantContent.push(currentToolUseBlock);
+              yield {
+                type: 'tool_use',
+                id: currentToolUseBlock.id,
+                name: currentToolUseBlock.name,
+                input: {},
+              };
+            }
+            currentToolUseBlock = null;
+            accumulatedJson = '';
+          }
+          currentTextBlock = null;
+        } else if (eventType === 'message_stop') {
+          // Add assistant response to conversation history
+          if (assistantContent.length > 0) {
+            this.conversationHistory.push({
+              role: 'assistant',
+              content: assistantContent.map((block) => {
+                if (block.type === 'text') {
+                  return { type: 'text' as const, text: block.text };
+                } else if (block.type === 'tool_use') {
+                  return {
+                    type: 'tool_use' as const,
+                    id: block.id,
+                    name: block.name,
+                    input: block.input,
+                  };
+                }
+                return null;
+              }).filter(Boolean) as Anthropic.Messages.ContentBlockParam[],
+            });
+          }
+        }
+      }
+
+      yield { type: 'done' };
+    } catch (error) {
+      // Handle different error types
+      if (error instanceof Anthropic.APIError) {
+        yield {
+          type: 'error',
+          message: `API Error (${error.status}): ${error.message}`,
+        };
+      } else if (error instanceof Anthropic.APIUserAbortError) {
+        yield {
+          type: 'error',
+          message: 'Request was cancelled',
+        };
+      } else if (error instanceof Error) {
+        if (error.message === 'Request cancelled' || error.name === 'AbortError') {
+          yield {
+            type: 'error',
+            message: 'Request was cancelled',
+          };
+        } else {
+          yield {
+            type: 'error',
+            message: error.message,
+          };
+        }
+      } else {
+        yield {
+          type: 'error',
+          message: 'An unknown error occurred',
+        };
+      }
+
+      yield { type: 'done' };
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+  }
+
+  /**
+   * Add a tool result to the conversation history.
+   * This should be called after a tool_use event and tool execution.
+   */
+  addToolResult(toolUseId: string, output: unknown, isError = false): void {
+    this.conversationHistory.push({
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: typeof output === 'string' ? output : JSON.stringify(output),
+          is_error: isError,
+        } as Anthropic.Messages.ToolResultBlockParam,
+      ],
+    });
+  }
+}
+
 export class ClaudeAdapter implements AgentRuntime {
   private apiKey?: string;
+  private baseURL?: string;
 
-  constructor(config: { apiKey?: string } = {}) {
+  constructor(config: { apiKey?: string; baseURL?: string } = {}) {
     this.apiKey = config.apiKey;
+    this.baseURL = config.baseURL;
   }
 
   async createSession(config: SessionConfig): Promise<AgentSession> {
-    // Placeholder - PR-06 will implement actual SDK integration
-    const session: AgentSession = {
-      id: generateId(),
-      async *sendMessage(message: string): AsyncGenerator<RuntimeEvent> {
-        yield { type: 'text', content: `Placeholder response for: ${message}` };
-        yield { type: 'done' };
-      },
-      cancel() {
-        console.log('Session cancelled');
-      }
-    };
+    const client = new Anthropic({
+      apiKey: this.apiKey,
+      baseURL: this.baseURL,
+      dangerouslyAllowBrowser: true, // Allow usage in Electron renderer
+    });
+
+    const session = new ClaudeSession(
+      generateId(),
+      client,
+      config
+    );
+
     return session;
   }
 
   listCapabilities(): RuntimeCapabilities {
     return {
-      models: ['claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307'],
+      models: [
+        'claude-3-opus-20240229',
+        'claude-3-sonnet-20240229',
+        'claude-3-haiku-20240307',
+        'claude-3-5-sonnet-20241022',
+        'claude-3-5-sonnet-latest',
+        'claude-3-5-haiku-20241022',
+        'claude-3-5-haiku-latest',
+        'claude-3-7-sonnet-20250219',
+        'claude-3-7-sonnet-latest',
+      ],
       supportsTools: true,
       supportsStreaming: true,
-      maxContextTokens: 200000
+      maxContextTokens: 200000,
     };
   }
 }
 
 function generateId(): string {
-  return `session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `session-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
+
+export default ClaudeAdapter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       typescript:
         specifier: ~5.7.3
         version: 5.7.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.12)
 
   packages/policy-engine:
     devDependencies:
@@ -97,6 +100,9 @@ importers:
       typescript:
         specifier: ~5.7.3
         version: 5.7.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.12)
 
   packages/storage:
     dependencies:


### PR DESCRIPTION
## Summary

This PR implements the Claude Runtime Adapter to integrate the Anthropic Claude SDK as the sole Runtime Provider for the Lynae AI coding workbench.

### Changes

- **feat:** Implement Claude Adapter SDK integration (PR-06)
  - Add `AgentRuntime` interface with `createSession()` and `listCapabilities()`
  - Add `AgentSession` interface with `sendMessage()` streaming support
  - Implement SDK-backed streaming with AsyncGenerator
  - Add tool definition and tool_use/tool_result event handling
  - Add conversation history management with memory limits
  
- **fix:** Address memory leak and add documentation
  - Implement history trimming to prevent unbounded growth
  - Add comprehensive JSDoc comments

- **fix:** Address race condition in request cancellation
  - Use AbortController for proper cancellation
  - Add state tracking for active requests

- **fix:** Improve error handling for invalid JSON in tool input
  - Gracefully handle malformed tool input JSON
  - Log warnings with context for debugging

- **feat:** Add token usage reporting
  - Track input/output tokens from stream events
  - Yield usage events for consumption

- **test:** Fix test mock variable leakage
  - Use factory pattern for test isolation

- **feat:** Add input validation for SessionConfig
  - Validate all config parameters before creating session

## Test Plan

- [ ] Run unit tests: `pnpm --filter @lynae/runtime-adapter-claude test`
- [ ] Run typecheck: `pnpm --filter @lynae/runtime-adapter-claude typecheck`
- [ ] Build package: `pnpm --filter @lynae/runtime-adapter-claude build`

## Related Issues

Closes #6