### PR TITLE
feat: rework PR-06 with Claude Agent SDK thin adapter

### DIFF
--- a/packages/runtime-adapters/claude/package.json
+++ b/packages/runtime-adapters/claude/package.json
@@ -20,7 +20,7 @@
     "clean": "node ../../scripts/clean.mjs dist"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.2.62"
   },
   "devDependencies": {
     "typescript": "~5.7.3",

--- a/packages/runtime-adapters/claude/src/__tests__/adapter.test.ts
+++ b/packages/runtime-adapters/claude/src/__tests__/adapter.test.ts
@@ -1,1102 +1,280 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type {
-  AgentRuntime,
-  RuntimeEvent,
-  SessionConfig,
-  ToolDefinition,
-} from '../index.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Query, SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { AgentRuntime, RuntimeEvent, SessionConfig } from '../index.js';
 
-// Mock APIError class
-class MockAPIError extends Error {
-  status: number;
-  constructor(status: number, message: string) {
-    super(message);
-    this.status = status;
-    this.name = 'APIError';
-  }
-}
+const mockQuery = vi.fn();
 
-// Mock APIUserAbortError class
-class MockAPIUserAbortError extends Error {
-  constructor() {
-    super('Request was aborted');
-    this.name = 'APIUserAbortError';
-  }
-}
-
-// Create a mock stream that implements async iterable
-type StreamEvent =
-  | { type: 'content_block_start'; index: number; content_block: { type: 'text'; text: string } | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> } }
-  | { type: 'content_block_delta'; index: number; delta: { type: 'text_delta'; text: string } | { type: 'input_json_delta'; partial_json: string } }
-  | { type: 'content_block_stop'; index: number }
-  | { type: 'message_stop' }
-  | { type: 'message_start'; message: { id: string; type: string; role: string; content: unknown[]; model: string; stop_reason: null; stop_sequence: null; usage: { input_tokens: number; output_tokens: number } } }
-  | { type: 'message_delta'; delta: { stop_reason: string | null; stop_sequence: string | null }; usage: { output_tokens: number } };
-
-function createMockStream(events: StreamEvent[]): { [Symbol.asyncIterator](): AsyncGenerator<StreamEvent> } {
+vi.mock('@anthropic-ai/claude-agent-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@anthropic-ai/claude-agent-sdk')>('@anthropic-ai/claude-agent-sdk');
   return {
+    ...actual,
+    query: (...args: unknown[]) => mockQuery(...args),
+  };
+});
+
+const { ClaudeAdapter } = await import('../index.js');
+
+function createMockQuery(messages: SDKMessage[], opts: { error?: Error } = {}): Query & { close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
+
+  const iterable = {
     async *[Symbol.asyncIterator]() {
-      for (const event of events) {
-        yield event;
+      for (const message of messages) {
+        yield message;
+      }
+
+      if (opts.error) {
+        throw opts.error;
       }
     },
   };
+
+  return {
+    ...iterable,
+    close,
+  } as unknown as Query & { close: ReturnType<typeof vi.fn> };
 }
 
-// Module-level variables that will be reset for each test
-let mockMessages = { stream: vi.fn() };
-let MockAnthropic: ReturnType<typeof Object.assign>;
+function createNeverEndingQuery(): Query & { close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
 
-// Factory function to create fresh mock instances for each test
-function createMockAnthropic() {
-  mockMessages = {
-    stream: vi.fn(),
+  const iterable = {
+    async *[Symbol.asyncIterator]() {
+      await new Promise(() => {});
+    },
   };
 
-  const mockAnthropicConstructor = vi.fn().mockImplementation(() => ({
-    messages: mockMessages,
-  }));
-
-  // Add static properties to mock
-  return Object.assign(mockAnthropicConstructor, {
-    APIError: MockAPIError,
-    APIUserAbortError: MockAPIUserAbortError,
-  });
+  return {
+    ...iterable,
+    close,
+  } as unknown as Query & { close: ReturnType<typeof vi.fn> };
 }
 
-vi.mock('@anthropic-ai/sdk', () => ({
-  get default() {
-    return MockAnthropic;
-  },
-}));
-
-// Type guard for text events
-function isTextEvent(event: RuntimeEvent): event is { type: 'text'; content: string } {
-  return event.type === 'text';
+async function collectEvents(stream: AsyncIterable<RuntimeEvent>): Promise<RuntimeEvent[]> {
+  const events: RuntimeEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
 }
 
-// Type guard for error events
-function isErrorEvent(event: RuntimeEvent): event is { type: 'error'; message: string } {
-  return event.type === 'error';
-}
-
-// Type guard for usage events
-function isUsageEvent(event: RuntimeEvent): event is { type: 'usage'; inputTokens: number; outputTokens: number } {
-  return event.type === 'usage';
-}
-
-// Import after mocking
-const { ClaudeAdapter: ClaudeAdapterClass } = await import('../index.js');
-
-describe('ClaudeAdapter', () => {
+describe('ClaudeAdapter (thin adapter)', () => {
   let adapter: AgentRuntime;
 
   beforeEach(() => {
-    // Create fresh mock instance for each test
-    MockAnthropic = createMockAnthropic();
     vi.clearAllMocks();
-    adapter = new ClaudeAdapterClass({ apiKey: 'test-api-key' }) as AgentRuntime;
+    adapter = new ClaudeAdapter();
   });
 
   describe('createSession', () => {
-    it('should create a session with valid ID', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        model: 'claude-3-5-sonnet-latest',
-      };
-
-      const session = await adapter.createSession(config);
-
-      expect(session).toBeDefined();
-      expect(session.id).toBeDefined();
+    it('creates a session with generated id', async () => {
+      const session = await adapter.createSession({ workspaceRoot: '/tmp/workspace' });
       expect(session.id).toMatch(/^session-\d+-[a-z0-9]+$/);
       expect(typeof session.sendMessage).toBe('function');
       expect(typeof session.cancel).toBe('function');
     });
 
-    it('should create session with default model when not specified', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-      expect(session).toBeDefined();
+    it('validates workspaceRoot', async () => {
+      await expect(adapter.createSession({} as SessionConfig)).rejects.toThrow('workspaceRoot is required');
+      await expect(adapter.createSession({ workspaceRoot: '' })).rejects.toThrow('workspaceRoot is required');
+      await expect(adapter.createSession({ workspaceRoot: '   ' })).rejects.toThrow('workspaceRoot cannot be empty');
+      await expect(adapter.createSession({ workspaceRoot: 123 as unknown as string })).rejects.toThrow('workspaceRoot must be a string');
     });
 
-    it('should throw error when workspaceRoot is missing', async () => {
-      const config = {} as SessionConfig;
+    it('validates optional fields', async () => {
+      await expect(
+        adapter.createSession({
+          workspaceRoot: '/tmp/workspace',
+          model: '',
+        })
+      ).rejects.toThrow('model cannot be empty');
 
-      await expect(adapter.createSession(config)).rejects.toThrow('workspaceRoot is required');
+      await expect(
+        adapter.createSession({
+          workspaceRoot: '/tmp/workspace',
+          allowedTools: ['Bash', ''],
+        })
+      ).rejects.toThrow('allowedTools entries must be non-empty strings');
+
+      await expect(
+        adapter.createSession({
+          workspaceRoot: '/tmp/workspace',
+          maxTurns: 0,
+        })
+      ).rejects.toThrow('maxTurns must be a positive integer');
     });
+  });
 
-    it('should throw error when workspaceRoot is empty string', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '   ',
-      };
+  describe('sendMessage', () => {
+    it('passes normalized options to Agent SDK query()', async () => {
+      const session = await adapter.createSession({
+        workspaceRoot: '/repo',
+        model: 'claude-sonnet-4-5',
+        systemPrompt: 'Be concise',
+        allowedTools: ['Bash', 'Read'],
+        includePartialMessages: true,
+        maxTurns: 3,
+      });
 
-      await expect(adapter.createSession(config)).rejects.toThrow('workspaceRoot cannot be empty');
-    });
-
-    it('should throw error when workspaceRoot is not a string', async () => {
-      const config = {
-        workspaceRoot: 123,
-      } as unknown as SessionConfig;
-
-      await expect(adapter.createSession(config)).rejects.toThrow('workspaceRoot must be a string');
-    });
-
-    it('should throw error when model is empty string', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        model: '',
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('model cannot be empty');
-    });
-
-    it('should throw error when maxTokens is not a positive integer', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        maxTokens: 0,
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('maxTokens must be a positive integer');
-    });
-
-    it('should throw error when maxTokens is negative', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        maxTokens: -100,
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('maxTokens must be a positive integer');
-    });
-
-    it('should throw error when temperature is out of range', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        temperature: 1.5,
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('temperature must be between 0 and 1');
-    });
-
-    it('should throw error when temperature is negative', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        temperature: -0.1,
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('temperature must be between 0 and 1');
-    });
-
-    it('should throw error when maxHistoryMessages is less than 1', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        maxHistoryMessages: 0,
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('maxHistoryMessages must be a positive integer');
-    });
-
-    it('should throw error when tools is not an array', async () => {
-      const config = {
-        workspaceRoot: '/test',
-        tools: 'not an array',
-      } as unknown as SessionConfig;
-
-      await expect(adapter.createSession(config)).rejects.toThrow('tools must be an array');
-    });
-
-    it('should throw error when tool is missing name', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        tools: [{ description: 'A tool', inputSchema: { type: 'object' } } as ToolDefinition],
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('Tool name is required');
-    });
-
-    it('should throw error when tool is missing description', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        tools: [{ name: 'test_tool', inputSchema: { type: 'object' } } as ToolDefinition],
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('Tool "test_tool" description is required');
-    });
-
-    it('should throw error when tool has invalid inputSchema', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test',
-        tools: [{ name: 'test_tool', description: 'A tool', inputSchema: { type: 'string' } } as unknown as ToolDefinition],
-      };
-
-      await expect(adapter.createSession(config)).rejects.toThrow('Tool "test_tool" inputSchema must be an object type');
-    });
-
-    it('should create session with tools', async () => {
-      const tools: ToolDefinition[] = [
+      const sdkQuery = createMockQuery([
         {
-          name: 'read_file',
-          description: 'Read a file from the filesystem',
-          inputSchema: {
-            type: 'object',
-            properties: { path: { type: 'string' } },
-            required: ['path'],
-          },
-        },
-      ];
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          usage: { input_tokens: 10, output_tokens: 20 },
+        } as unknown as SDKMessage,
+      ]);
+      mockQuery.mockReturnValueOnce(sdkQuery);
 
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        tools,
-      };
+      const events = await collectEvents(session.sendMessage('hello'));
 
-      const session = await adapter.createSession(config);
-      expect(session).toBeDefined();
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(mockQuery).toHaveBeenCalledWith({
+        prompt: 'hello',
+        options: expect.objectContaining({
+          cwd: '/repo',
+          model: 'claude-sonnet-4-5',
+          systemPrompt: 'Be concise',
+          allowedTools: ['Bash', 'Read'],
+          includePartialMessages: true,
+          maxTurns: 3,
+        }),
+      });
+
+      expect(events).toEqual([
+        { type: 'usage', inputTokens: 10, outputTokens: 20 },
+        { type: 'done' },
+      ]);
+    });
+
+    it('maps assistant text/tool_use blocks and result usage', async () => {
+      const session = await adapter.createSession({ workspaceRoot: '/repo' });
+      mockQuery.mockReturnValueOnce(
+        createMockQuery([
+          {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'text', text: 'hello ' },
+                { type: 'tool_use', id: 'tool_1', name: 'Bash', input: { command: 'ls' } },
+                { type: 'text', text: 'world' },
+              ],
+            },
+            parent_tool_use_id: null,
+            uuid: 'a1',
+            session_id: 's1',
+          } as unknown as SDKMessage,
+          {
+            type: 'result',
+            subtype: 'success',
+            is_error: false,
+            usage: { input_tokens: 11, output_tokens: 22 },
+          } as unknown as SDKMessage,
+        ])
+      );
+
+      const events = await collectEvents(session.sendMessage('run'));
+
+      expect(events).toEqual([
+        { type: 'text', content: 'hello ' },
+        { type: 'tool_use', id: 'tool_1', name: 'Bash', input: { command: 'ls' } },
+        { type: 'text', content: 'world' },
+        { type: 'usage', inputTokens: 11, outputTokens: 22 },
+        { type: 'done' },
+      ]);
+    });
+
+    it('maps assistant error and result error into runtime errors', async () => {
+      const session = await adapter.createSession({ workspaceRoot: '/repo' });
+      mockQuery.mockReturnValueOnce(
+        createMockQuery([
+          {
+            type: 'assistant',
+            message: { content: [] },
+            parent_tool_use_id: null,
+            error: 'rate_limit',
+          } as unknown as SDKMessage,
+          {
+            type: 'result',
+            subtype: 'error_during_execution',
+            is_error: true,
+            errors: ['permission denied', 'timeout'],
+          } as unknown as SDKMessage,
+        ])
+      );
+
+      const events = await collectEvents(session.sendMessage('run'));
+
+      expect(events).toEqual([
+        { type: 'error', message: 'Claude Agent SDK assistant error: rate_limit' },
+        { type: 'error', message: 'permission denied; timeout' },
+        { type: 'done' },
+      ]);
+    });
+
+    it('maps thrown errors into runtime error event', async () => {
+      const session = await adapter.createSession({ workspaceRoot: '/repo' });
+      mockQuery.mockReturnValueOnce(createMockQuery([], { error: new Error('boom') }));
+
+      const events = await collectEvents(session.sendMessage('run'));
+
+      expect(events).toEqual([
+        { type: 'error', message: 'boom' },
+        { type: 'done' },
+      ]);
+    });
+
+    it('cancels previous active query when a new turn starts', async () => {
+      const session = await adapter.createSession({ workspaceRoot: '/repo' });
+
+      const firstQuery = createNeverEndingQuery();
+      const secondQuery = createMockQuery([
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        } as unknown as SDKMessage,
+      ]);
+
+      mockQuery
+        .mockReturnValueOnce(firstQuery)
+        .mockReturnValueOnce(secondQuery);
+
+      const firstTurn = session.sendMessage('first');
+      void firstTurn[Symbol.asyncIterator]().next();
+
+      const secondEvents = await collectEvents(session.sendMessage('second'));
+
+      expect(firstQuery.close).toHaveBeenCalledTimes(1);
+      expect(secondEvents).toEqual([
+        { type: 'usage', inputTokens: 1, outputTokens: 1 },
+        { type: 'done' },
+      ]);
+    });
+
+    it('cancel() closes active query', async () => {
+      const session = await adapter.createSession({ workspaceRoot: '/repo' });
+      const firstQuery = createNeverEndingQuery();
+      mockQuery.mockReturnValueOnce(firstQuery);
+
+      const stream = session.sendMessage('long-running');
+      void stream[Symbol.asyncIterator]().next();
+
+      session.cancel();
+
+      expect(firstQuery.close).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('listCapabilities', () => {
-    it('should return correct capability list', () => {
+    it('returns capabilities in normalized shape', () => {
       const capabilities = adapter.listCapabilities();
 
       expect(capabilities.supportsTools).toBe(true);
       expect(capabilities.supportsStreaming).toBe(true);
-      expect(capabilities.maxContextTokens).toBe(200000);
-      expect(capabilities.models).toContain('claude-3-opus-20240229');
-      expect(capabilities.models).toContain('claude-3-5-sonnet-latest');
-      expect(capabilities.models).toContain('claude-3-7-sonnet-latest');
-    });
-
-    it('should include all expected models', () => {
-      const capabilities = adapter.listCapabilities();
-      const expectedModels = [
-        'claude-3-opus-20240229',
-        'claude-3-sonnet-20240229',
-        'claude-3-haiku-20240307',
-        'claude-3-5-sonnet-20241022',
-        'claude-3-5-sonnet-latest',
-        'claude-3-5-haiku-20241022',
-        'claude-3-5-haiku-latest',
-        'claude-3-7-sonnet-20250219',
-        'claude-3-7-sonnet-latest',
-      ];
-
-      expectedModels.forEach((model) => {
-        expect(capabilities.models).toContain(model);
-      });
-    });
-  });
-
-  describe('sendMessage streaming', () => {
-    it('should yield text events in correct order', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Mock stream events
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ' ' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'world' } },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Hello')) {
-        events.push(event);
-      }
-
-      expect(events).toHaveLength(4); // 3 text events + done
-      expect(events[0]).toEqual({ type: 'text', content: 'Hello' });
-      expect(events[1]).toEqual({ type: 'text', content: ' ' });
-      expect(events[2]).toEqual({ type: 'text', content: 'world' });
-      expect(events[3]).toEqual({ type: 'done' });
-    });
-
-    it('should accumulate text across multiple deltas', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'First' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Second' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Third' } },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const textEvents: Array<{ type: 'text'; content: string }> = [];
-      for await (const event of session.sendMessage('Test')) {
-        if (isTextEvent(event)) {
-          textEvents.push(event);
-        }
-      }
-
-      expect(textEvents).toHaveLength(3);
-      expect(textEvents[0].content).toBe('First');
-      expect(textEvents[1].content).toBe('Second');
-      expect(textEvents[2].content).toBe('Third');
-    });
-
-    it('should yield usage event with token counts', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Mock stream with usage information from message_start and message_delta events
-      mockMessages.stream.mockImplementationOnce(() =>
-        ({
-          async *[Symbol.asyncIterator]() {
-            // message_start contains input token usage
-            yield {
-              type: 'message_start',
-              message: {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [],
-                model: 'claude-3-5-sonnet-latest',
-                stop_reason: null,
-                stop_sequence: null,
-                usage: {
-                  input_tokens: 150,
-                  output_tokens: 0,
-                },
-              },
-            };
-            yield { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } };
-            yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } };
-            yield { type: 'content_block_stop', index: 0 };
-            // message_delta contains output token usage (cumulative)
-            yield {
-              type: 'message_delta',
-              delta: { stop_reason: 'end_turn', stop_sequence: null },
-              usage: { output_tokens: 42 },
-            };
-            yield { type: 'message_stop' };
-          },
-        })
-      );
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Hi')) {
-        events.push(event);
-      }
-
-      const usageEvent = events.find(isUsageEvent);
-      expect(usageEvent).toBeDefined();
-      expect(usageEvent?.inputTokens).toBe(150);
-      expect(usageEvent?.outputTokens).toBe(42);
-    });
-
-    it('should handle missing usage information gracefully', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Mock stream without usage information (no message_start with usage or message_delta)
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Hi')) {
-        events.push(event);
-      }
-
-      // Should not have a usage event but should complete normally
-      const usageEvent = events.find(isUsageEvent);
-      expect(usageEvent).toBeUndefined();
-      expect(events.some((e) => e.type === 'done')).toBe(true);
-    });
-  });
-
-  describe('tool_use handling', () => {
-    it('should correctly parse and yield tool_use events', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        tools: [
-          {
-            name: 'get_weather',
-            description: 'Get weather for a location',
-            inputSchema: {
-              type: 'object',
-              properties: { location: { type: 'string' } },
-              required: ['location'],
-            },
-          },
-        ],
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'tool_123', name: 'get_weather', input: {} },
-        },
-        {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'input_json_delta', partial_json: '{"location": "San Francisco"}' },
-        },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('What is the weather?')) {
-        events.push(event);
-      }
-
-      const toolUseEvent = events.find((e): e is { type: 'tool_use'; id: string; name: string; input: unknown } =>
-        e.type === 'tool_use'
-      );
-      expect(toolUseEvent).toBeDefined();
-      expect(toolUseEvent).toMatchObject({
-        type: 'tool_use',
-        id: 'tool_123',
-        name: 'get_weather',
-        input: { location: 'San Francisco' },
-      });
-    });
-
-    it('should handle multiple tool_use blocks', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        tools: [
-          {
-            name: 'tool_a',
-            description: 'Tool A',
-            inputSchema: { type: 'object', properties: {} },
-          },
-          {
-            name: 'tool_b',
-            description: 'Tool B',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'tool_1', name: 'tool_a', input: {} },
-        },
-        { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{}' } },
-        { type: 'content_block_stop', index: 0 },
-        {
-          type: 'content_block_start',
-          index: 1,
-          content_block: { type: 'tool_use', id: 'tool_2', name: 'tool_b', input: {} },
-        },
-        { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{}' } },
-        { type: 'content_block_stop', index: 1 },
-        { type: 'message_stop' },
-      ]));
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Use multiple tools')) {
-        events.push(event);
-      }
-
-      const toolUseEvents = events.filter((e): e is { type: 'tool_use'; id: string; name: string; input: unknown } =>
-        e.type === 'tool_use'
-      );
-      expect(toolUseEvents).toHaveLength(2);
-      expect(toolUseEvents[0]).toMatchObject({ id: 'tool_1', name: 'tool_a' });
-      expect(toolUseEvents[1]).toMatchObject({ id: 'tool_2', name: 'tool_b' });
-    });
-
-    it('should handle empty tool input', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        tools: [
-          {
-            name: 'simple_tool',
-            description: 'A simple tool',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'tool_empty', name: 'simple_tool', input: {} },
-        },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Use tool')) {
-        events.push(event);
-      }
-
-      const toolUseEvent = events.find((e): e is { type: 'tool_use'; id: string; name: string; input: unknown } =>
-        e.type === 'tool_use'
-      );
-      expect(toolUseEvent).toBeDefined();
-      expect(toolUseEvent).toMatchObject({
-        type: 'tool_use',
-        id: 'tool_empty',
-        name: 'simple_tool',
-        input: {},
-      });
-    });
-
-    it('should handle invalid JSON in tool input gracefully', async () => {
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        tools: [
-          {
-            name: 'test_tool',
-            description: 'A test tool',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Simulate invalid JSON in the tool input stream
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        {
-          type: 'content_block_start',
-          index: 0,
-          content_block: { type: 'tool_use', id: 'tool_invalid', name: 'test_tool', input: {} },
-        },
-        {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'input_json_delta', partial_json: '{invalid json' },
-        },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Use tool with invalid JSON')) {
-        events.push(event);
-      }
-
-      // Should still yield a tool_use event with empty input
-      const toolUseEvent = events.find((e): e is { type: 'tool_use'; id: string; name: string; input: unknown } =>
-        e.type === 'tool_use'
-      );
-      expect(toolUseEvent).toBeDefined();
-      expect(toolUseEvent).toMatchObject({
-        type: 'tool_use',
-        id: 'tool_invalid',
-        name: 'test_tool',
-        input: {},
-      });
-
-      // Should log a warning with details about the parse failure
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      const warnCall = consoleWarnSpy.mock.calls[0][0];
-      expect(warnCall).toContain('Failed to parse tool input JSON');
-      expect(warnCall).toContain('test_tool');
-      expect(warnCall).toContain('tool_invalid');
-      expect(warnCall).toContain('{invalid json');
-
-      consoleWarnSpy.mockRestore();
-    });
-  });
-
-  describe('error handling', () => {
-    it('should map API errors to RuntimeEvent errors', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => {
-        throw new MockAPIError(401, 'Invalid API key');
-      });
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Hello')) {
-        events.push(event);
-      }
-
-      const errorEvent = events.find(isErrorEvent);
-      expect(errorEvent).toBeDefined();
-      expect(errorEvent?.message).toContain('401');
-      expect(errorEvent?.message).toContain('Invalid API key');
-
-      const doneEvent = events.find((e) => e.type === 'done');
-      expect(doneEvent).toBeDefined();
-    });
-
-    it('should handle rate limit errors', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => {
-        throw new MockAPIError(429, 'Rate limit exceeded');
-      });
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Hello')) {
-        events.push(event);
-      }
-
-      const errorEvent = events.find(isErrorEvent);
-      expect(errorEvent?.message).toContain('429');
-    });
-
-    it('should handle generic errors', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => {
-        throw new Error('Network error');
-      });
-
-      const events: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Hello')) {
-        events.push(event);
-      }
-
-      const errorEvent = events.find(isErrorEvent);
-      expect(errorEvent?.message).toBe('Network error');
-    });
-  });
-
-  describe('cancellation', () => {
-    it('should support cancelling streaming via abort controller', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Create a delayed async iterator to simulate streaming
-      let abortSignal: AbortSignal | undefined;
-      mockMessages.stream.mockImplementation((params: unknown, options: { signal?: AbortSignal }) => {
-        abortSignal = options?.signal;
-        return {
-          async *[Symbol.asyncIterator]() {
-            yield { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } };
-            yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } };
-
-            // Check if aborted
-            if (abortSignal?.aborted) {
-              throw new Error('Request cancelled');
-            }
-
-            yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: ' world' } };
-            yield { type: 'content_block_stop', index: 0 };
-            yield { type: 'message_stop' };
-          },
-        };
-      });
-
-      const events: RuntimeEvent[] = [];
-
-      // Use for await pattern instead of manual generator iteration
-      let cancelled = false;
-      try {
-        for await (const event of session.sendMessage('Hello')) {
-          events.push(event);
-          // Cancel after first event
-          if (!cancelled) {
-            session.cancel();
-            cancelled = true;
-          }
-        }
-      } catch {
-        // Expected to potentially throw or yield error
-      }
-
-      // Should have received at least one text event
-      expect(events.length).toBeGreaterThanOrEqual(1);
-      expect(events[0]).toEqual({ type: 'text', content: 'Hello' });
-    });
-
-    it('should handle cancel when no active request', async () => {
-      // Should not throw when cancel is called without an active request
-      const testAdapter = new ClaudeAdapterClass({ apiKey: 'test' });
-      const session = await testAdapter.createSession({ workspaceRoot: '/test' });
-      expect(() => session.cancel()).not.toThrow();
-    });
-  });
-
-  describe('conversation history', () => {
-    it('should maintain conversation history across messages', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // First message - use mockImplementation to ensure isolation
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Response 1' } },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events1: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Message 1')) {
-        events1.push(event);
-      }
-
-      expect(events1.some((e) => isTextEvent(e) && e.content === 'Response 1')).toBe(true);
-
-      // Second message - verify history is maintained by checking mock calls
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Response 2' } },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      const events2: RuntimeEvent[] = [];
-      for await (const event of session.sendMessage('Message 2')) {
-        events2.push(event);
-      }
-
-      expect(events2.some((e) => isTextEvent(e) && e.content === 'Response 2')).toBe(true);
-
-      // Verify that messages.stream was called with accumulated history
-      const secondCall = mockMessages.stream.mock.calls[1];
-      // Second call should have more messages than the first call due to conversation history
-      expect(secondCall[0].messages.length).toBeGreaterThan(1);
-    });
-  });
-
-  describe('configuration options', () => {
-    it('should pass custom model to API', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        model: 'claude-3-opus-20240229',
-        maxTokens: 4096,
-        temperature: 0.5,
-        systemPrompt: 'You are a helpful assistant',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'message_stop' },
-      ]));
-
-      for await (const _ of session.sendMessage('Hello')) {
-        // consume events
-      }
-
-      const callArgs = mockMessages.stream.mock.calls[0][0];
-      expect(callArgs.model).toBe('claude-3-opus-20240229');
-      expect(callArgs.max_tokens).toBe(4096);
-      expect(callArgs.temperature).toBe(0.5);
-      expect(callArgs.system).toBe('You are a helpful assistant');
-    });
-
-    it('should use default values when not specified', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'message_stop' },
-      ]));
-
-      for await (const _ of session.sendMessage('Hello')) {
-        // consume events
-      }
-
-      const callArgs = mockMessages.stream.mock.calls[0][0];
-      expect(callArgs.model).toBe('claude-3-5-sonnet-latest');
-      expect(callArgs.max_tokens).toBe(8192);
-      expect(callArgs.temperature).toBe(0.7);
-      expect(callArgs.system).toBeUndefined();
-    });
-  });
-
-  describe('ClaudeSession.addToolResult', () => {
-    it('should add tool result to conversation history', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Cast to access internal method
-      const claudeSession = session as unknown as {
-        addToolResult(toolUseId: string, output: unknown, isError?: boolean): void;
-      };
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'message_stop' },
-      ]));
-
-      // Add a tool result
-      claudeSession.addToolResult('tool_123', { temperature: 72 }, false);
-
-      // Send a message and verify the tool result is included
-      for await (const _ of session.sendMessage('Thanks')) {
-        // consume events
-      }
-
-      const callArgs = mockMessages.stream.mock.calls[0][0];
-      // Should have user message ("Thanks") and previous tool result
-      expect(callArgs.messages.length).toBeGreaterThanOrEqual(1);
-
-      // Find the tool result message
-      const toolResultMessage = callArgs.messages.find(
-        (m: { role: string; content: unknown }) =>
-          m.role === 'user' &&
-          Array.isArray(m.content) &&
-          m.content.some((c: { type: string }) => c.type === 'tool_result')
-      );
-      expect(toolResultMessage).toBeDefined();
-    });
-  });
-
-  describe('conversation history trimming', () => {
-    it('should trim history when exceeding maxHistoryMessages', async () => {
-      // Use a small limit for testing
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        maxHistoryMessages: 4, // Allow only 4 messages (2 exchanges)
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Cast to access internal state
-      const claudeSession = session as unknown as {
-        sendMessage(message: string): AsyncIterable<RuntimeEvent>;
-      };
-
-      // Simulate multiple message exchanges
-      for (let i = 0; i < 5; i++) {
-        mockMessages.stream.mockImplementation(() => createMockStream([
-          { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: `Response ${i}` } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'message_stop' },
-        ]));
-
-        for await (const _ of claudeSession.sendMessage(`Message ${i}`)) {
-          // consume events
-        }
-      }
-
-      // Trimming happens when a user message is added, but the assistant response
-      // is added after. So we can have at most maxHistoryMessages + 1 temporarily.
-      // After many exchanges, the history should be bounded.
-      const lastCall = mockMessages.stream.mock.calls[4];
-      // Should be trimmed to at most maxHistoryMessages (4) at the start of sendMessage
-      expect(lastCall[0].messages.length).toBeLessThanOrEqual(5);
-      // Verify we have at least the most recent messages
-      expect(lastCall[0].messages.length).toBeGreaterThanOrEqual(2);
-    });
-
-    it('should use default limit of 100 when maxHistoryMessages not specified', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        // maxHistoryMessages not specified - should use default of 100
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Cast to access internal state
-      const claudeSession = session as unknown as {
-        sendMessage(message: string): AsyncIterable<RuntimeEvent>;
-      };
-
-      // Simulate a few exchanges - should not be trimmed with default limit
-      for (let i = 0; i < 3; i++) {
-        mockMessages.stream.mockImplementation(() => createMockStream([
-          { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-          { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: `Response ${i}` } },
-          { type: 'content_block_stop', index: 0 },
-          { type: 'message_stop' },
-        ]));
-
-        for await (const _ of claudeSession.sendMessage(`Message ${i}`)) {
-          // consume events
-        }
-      }
-
-      // All 6 messages (3 user + 3 assistant) should be preserved
-      const lastCall = mockMessages.stream.mock.calls[2];
-      expect(lastCall[0].messages.length).toBe(6);
-    });
-
-    it('should trim history after adding tool results', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-        maxHistoryMessages: 2,
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Cast to access internal methods
-      const claudeSession = session as unknown as {
-        addToolResult(toolUseId: string, output: unknown, isError?: boolean): void;
-        sendMessage(message: string): AsyncIterable<RuntimeEvent>;
-      };
-
-      // Add multiple tool results
-      for (let i = 0; i < 5; i++) {
-        claudeSession.addToolResult(`tool_${i}`, { result: i });
-      }
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'message_stop' },
-      ]));
-
-      // Send a message to trigger history check
-      for await (const _ of claudeSession.sendMessage('Final message')) {
-        // consume events
-      }
-
-      // History should be trimmed to at most 2 messages
-      const lastCall = mockMessages.stream.mock.calls[0];
-      expect(lastCall[0].messages.length).toBeLessThanOrEqual(2);
-    });
-  });
-
-  describe('concurrent request handling', () => {
-    it('should create new abort controller for each request', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      // Track abort signals from both requests
-      const abortSignals: (AbortSignal | undefined)[] = [];
-
-      // Use mockImplementationOnce to ensure each call gets a fresh mock
-      mockMessages.stream
-        .mockImplementationOnce((params: unknown, options: { signal?: AbortSignal }) => {
-          abortSignals.push(options?.signal);
-          return createMockStream([
-            { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Response 1' } },
-            { type: 'content_block_stop', index: 0 },
-            { type: 'message_stop' },
-          ]);
-        })
-        .mockImplementationOnce((params: unknown, options: { signal?: AbortSignal }) => {
-          abortSignals.push(options?.signal);
-          return createMockStream([
-            { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Response 2' } },
-            { type: 'content_block_stop', index: 0 },
-            { type: 'message_stop' },
-          ]);
-        });
-
-      // Start first request and fully consume it
-      const generator1 = session.sendMessage('First message');
-      const events1: RuntimeEvent[] = [];
-      for await (const event of generator1) {
-        events1.push(event);
-      }
-
-      // Start second request and fully consume it
-      const generator2 = session.sendMessage('Second message');
-      const events2: RuntimeEvent[] = [];
-      for await (const event of generator2) {
-        events2.push(event);
-      }
-
-      // Verify both requests received different abort signals (proper isolation)
-      expect(abortSignals.length).toBe(2);
-      expect(abortSignals[0]).not.toBe(abortSignals[1]);
-
-      // Verify the first request completed (either normally or cancelled)
-      expect(events1.some((e) => e.type === 'done' || (isErrorEvent(e) && e.message.includes('cancelled')))).toBe(true);
-
-      // Second request should complete normally
-      expect(events2.some((e) => e.type === 'done')).toBe(true);
-    });
-
-    it('should handle rapid cancel and sendMessage calls', async () => {
-      const config: SessionConfig = {
-        workspaceRoot: '/test/workspace',
-      };
-
-      const session = await adapter.createSession(config);
-
-      mockMessages.stream.mockImplementation(() => createMockStream([
-        { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
-        { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello' } },
-        { type: 'content_block_stop', index: 0 },
-        { type: 'message_stop' },
-      ]));
-
-      // Start a request
-      const generator = session.sendMessage('Message');
-
-      // Immediately cancel it
-      session.cancel();
-
-      // Then start another request
-      const generator2 = session.sendMessage('Another message');
-
-      // Collect events from first generator (should be cancelled or empty)
-      const events1: RuntimeEvent[] = [];
-      try {
-        for await (const event of generator) {
-          events1.push(event);
-        }
-      } catch {
-        // Expected
-      }
-
-      // Collect events from second generator (should complete)
-      const events2: RuntimeEvent[] = [];
-      for await (const event of generator2) {
-        events2.push(event);
-      }
-
-      // Second request should complete successfully
-      expect(events2.some((e) => isTextEvent(e) && e.content === 'Hello')).toBe(true);
-      expect(events2.some((e) => e.type === 'done')).toBe(true);
+      expect(capabilities.maxContextTokens).toBeGreaterThan(0);
+      expect(capabilities.models.length).toBeGreaterThan(0);
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,9 @@ importers:
 
   packages/runtime-adapters/claude:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.39.0
-        version: 0.39.0
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.62
+        version: 0.2.62(zod@4.3.6)
     devDependencies:
       typescript:
         specifier: ~5.7.3
@@ -142,18 +142,23 @@ packages:
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
     dev: true
 
-  /@anthropic-ai/sdk@0.39.0:
-    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+  /@anthropic-ai/claude-agent-sdk@0.2.62(zod@4.3.6):
+    resolution: {integrity: sha512-exRJ2djKP6erRpUrtnVf5iXzqeS9dAie9d1ghODZVVXdLqieSqCpaAhZhe0hL1yvP33OL0J5CgT9RAyPzhYY9A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
     dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
+      zod: 4.3.6
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     dev: false
 
   /@asamuzakjp/css-color@5.0.1:
@@ -1102,6 +1107,157 @@ packages:
         optional: true
     dev: true
 
+  /@img/sharp-darwin-arm64@0.34.5:
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-darwin-x64@0.34.5:
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-darwin-arm64@1.2.4:
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-darwin-x64@1.2.4:
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-linux-arm64@1.2.4:
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-linux-arm@1.2.4:
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-linux-x64@1.2.4:
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-linuxmusl-arm64@1.2.4:
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-libvips-linuxmusl-x64@1.2.4:
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-linux-arm64@0.34.5:
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-linux-arm@0.34.5:
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-linux-x64@0.34.5:
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-linuxmusl-arm64@0.34.5:
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-linuxmusl-x64@0.34.5:
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    dev: false
+    optional: true
+
+  /@img/sharp-win32-arm64@0.34.5:
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@img/sharp-win32-x64@0.34.5:
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@jridgewell/gen-mapping@0.3.13:
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
     dependencies:
@@ -1494,19 +1650,6 @@ packages:
       '@types/node': 22.19.12
     dev: true
 
-  /@types/node-fetch@2.6.13:
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-    dependencies:
-      '@types/node': 22.19.12
-      form-data: 4.0.5
-    dev: false
-
-  /@types/node@18.19.130:
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: false
-
   /@types/node@20.19.34:
     resolution: {integrity: sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==}
     dependencies:
@@ -1686,24 +1829,10 @@ packages:
       tinyrainbow: 3.0.3
     dev: true
 
-  /abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-    dependencies:
-      event-target-shim: 5.0.1
-    dev: false
-
   /agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
     dev: true
-
-  /agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      humanize-ms: 1.2.1
-    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1730,10 +1859,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
     dev: true
-
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1831,14 +1956,6 @@ packages:
       responselike: 2.0.1
     dev: true
 
-  /call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-    dev: false
-
   /caniuse-lite@1.0.30001774:
     resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
     dev: true
@@ -1873,13 +1990,6 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: true
-
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1979,11 +2089,6 @@ packages:
       object-keys: 1.1.1
     dev: true
     optional: true
-
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: false
 
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2115,15 +2220,6 @@ packages:
       better-sqlite3: 12.6.2
     dev: false
 
-  /dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-    dev: false
-
   /electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
     dev: true
@@ -2164,31 +2260,20 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
     dev: true
-
-  /es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      es-errors: 1.3.0
-    dev: false
-
-  /es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-    dev: false
 
   /es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -2320,11 +2405,6 @@ packages:
       '@types/estree': 1.0.8
     dev: true
 
-  /event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-    dev: false
-
   /expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -2371,29 +2451,6 @@ packages:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
     dev: false
 
-  /form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-    dev: false
-
-  /form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-    dev: false
-
-  /formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
-    dev: false
-
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: false
@@ -2423,10 +2480,6 @@ packages:
     dev: true
     optional: true
 
-  /function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: false
-
   /gel@2.2.0:
     resolution: {integrity: sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==}
     engines: {node: '>= 18.0.0'}
@@ -2446,30 +2499,6 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
     dev: true
-
-  /get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      math-intrinsics: 1.1.0
-    dev: false
-
-  /get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
-    dev: false
 
   /get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -2515,6 +2544,9 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
@@ -2544,25 +2576,6 @@ packages:
       es-define-property: 1.0.1
     dev: true
     optional: true
-
-  /has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  /has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: 1.1.0
-    dev: false
-
-  /hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      function-bind: 1.1.2
-    dev: false
 
   /html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -2604,12 +2617,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-    dependencies:
-      ms: 2.1.3
-    dev: false
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2754,26 +2761,9 @@ packages:
     dev: true
     optional: true
 
-  /math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-    dev: false
-
   /mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
     dev: true
-
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: false
-
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.52.0
-    dev: false
 
   /mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -2799,6 +2789,7 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
 
   /nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2815,24 +2806,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.7.4
-    dev: false
-
-  /node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-    dev: false
-
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
     dev: false
 
   /node-releases@2.0.27:
@@ -3294,10 +3267,6 @@ packages:
       tldts: 7.0.23
     dev: true
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
-
   /tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -3383,10 +3352,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
-
-  /undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: false
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3651,15 +3616,6 @@ packages:
       xml-name-validator: 5.0.0
     dev: true
 
-  /web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-    dev: false
-
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
-
   /webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -3680,13 +3636,6 @@ packages:
     transitivePeerDependencies:
       - '@noble/hashes'
     dev: true
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-    dev: false
 
   /which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
@@ -3727,3 +3676,7 @@ packages:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
     dev: true
+
+  /zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+    dev: false


### PR DESCRIPTION
## Summary

This PR replaces the previous thick runtime adapter approach with the new Agent SDK thin-adapter design.

- Uses `@anthropic-ai/claude-agent-sdk` as the runtime integration
- Removes direct dependency on `@anthropic-ai/sdk` from the runtime-adapter package
- Refactors adapter to focus on:
  - Agent SDK query startup
  - RuntimeEvent mapping (text/tool_use/usage/error/done)
  - error normalization + cancellation wiring
- Removes duplicated runtime-core logic (manual conversation history + manual tool-loop plumbing)
- Updates PR-06 docs/planning artifacts to match the new architecture

## Breaking Change

- `AgentSession.addToolResult()` has been removed.
- Adapter-level `tool_result` runtime events are no longer emitted.
- Tool orchestration and result handling are delegated to the Claude Agent SDK runtime loop.

## Validation

- `pnpm --filter @lynae/runtime-adapter-claude typecheck`
- `pnpm --filter @lynae/runtime-adapter-claude test`

## Related

- Supersedes closed PR #24
- Re-aligns with reopened issue #6
